### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,25 @@ Stackmat.js is a library for JavaScript which helps you to access the Stackmat T
 
 Demo: http://timhabermaas.github.io/stackmat.js/
 
+## Installation
+```shell
+npm install stackmat.js
+```
+
 ## Usage
 
 First, create a `Stackmat.Timer` object and pass in a callback function which gets called every time the timer sends a signal - around five times a second.
 
 ```javascript
-var options = {
-  signalReceived: function(state) {
+import { Stackmat } from 'stackmat.js';
+
+const options = {
+  signalReceived(state) {
     console.log("Current Time: " + signal.getTimeAsString())
   }
 };
-var timer = new Stackmat.Timer(options);
+
+const timer = new Stackmat.Timer(options);
 ```
 
 then enable capturing input by calling `start`
@@ -43,9 +51,9 @@ state.isRightHandPressed();    // => false
 More options:
 
 ```javascript
-var options = {
-    onNonSupportedBrowser: function(){...},
-    signalReceived: function(state){...}
+const options = {
+    onNonSupportedBrowser(){...},
+    signalReceived(state){...}
 }
 ```
 


### PR DESCRIPTION
I didn't realize this module was already on `npm` until I looked in the issues, so it might be worthwhile to put it in the docs. Also, it took me some time to figure out how to import it as I had been trying stuff like

```js
import Stackmat from 'stackmat.js'
```

when I should have been doing

```js
import { Stackmat } from 'stackmat.js'
```

since I realized you did `exports.Stackmat = ...` after reading your code, so I think it might be a good idea to have import instructions in your **Usage** example. I made the examples use ES6 syntax, but I can revert everything back to ES5 and change the import line to `var Stackmat = require('stackmat.js').Stackmat` if you'd prefer that.